### PR TITLE
Timeout correctly even when a Promise never resolves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 sudo: false
 node_js:
-  - '0.10'
   - '0.12'
   - '4.0'
+  - '8.0'
+  - '10.0'
   - stable

--- a/index.js
+++ b/index.js
@@ -2,17 +2,23 @@ module.exports = function (promise, timeout, opts) {
     var Promise     = promise.constructor;
     var rejectWith  = opts && opts.rejectWith;
     var resolveWith = opts && opts.resolveWith;
+    var timer;
 
     var timeoutPromise = new Promise(function (resolve, reject) {
-        var timer = setTimeout(function () {
+        timer = setTimeout(function () {
             if (rejectWith !== void 0)
                 reject(rejectWith);
             else
                 resolve(resolveWith);
         }, timeout);
-
-        timer.unref();
     });
 
-    return Promise.race([timeoutPromise, promise]);
+    return Promise.race([timeoutPromise, promise])
+        .then(function (value) {
+            timer.unref();
+            return value;
+        }, function (error) {
+            timer.unref();
+            throw error;
+        });
 };

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
   "files": [
     "index.js"
   ],
+  "engines": {
+    "node": ">= 0.12"
+  },
   "devDependencies": {
-    "mocha": "^2.3.4",
-    "pinkie-promise": "^2.0.0"
+    "mocha": "^2.3.4"
   }
 }

--- a/test/bad-promise-example
+++ b/test/bad-promise-example
@@ -1,0 +1,21 @@
+var timeLimit = require('../index');
+
+function run() {
+  const promise = new Promise(function (resolve, reject) {
+    // Intentionally do nothing to mimic a bug in a poorly written
+    // promise wrapper
+  });
+
+  return timeLimit(promise, 100);
+}
+
+run()
+  .then(function () {
+    // Return a special exit code so that's
+    // possible to detect that the .then executed
+    process.exitCode = 42;
+  })
+  .catch(function (e) {
+    process.exitCode = -1;
+    console.error(e);
+  });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert    = require('assert');
 var Promise   = require('pinkie-promise');
 var timeLimit = require('../');
+var fork      = require('child_process').fork;
 
 function createTestPromise () {
     return new Promise(function (resolve) {
@@ -26,6 +27,24 @@ it('Should resolve promise on timeout', function () {
         .then(function (val) {
             assert(!val);
         });
+});
+
+it('Should resolve promise on timeout even with a new Promise that does not resolve', function () {
+    // This test forks a process that uses the time-limit-promise implementation.
+    // The behavior being reproduced depends on being able to be sure that the
+    // event loop is empty when it executes and mocha installs too many timers
+    // and other work to reproduce the conditions needed.
+    var child = fork('./test/bad-promise-example');
+    return new Promise(function (resolve, reject) {
+        child.on('exit', function (code) {
+            if (code !== 42) {
+                console.log('Result', code);
+                throw new Error('The process did not execute the then block');
+            }
+            resolve();
+        });
+        child.on('error', reject);
+    });
 });
 
 it('Should resolve promise on timeout with the provided value', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 var assert    = require('assert');
-var Promise   = require('pinkie-promise');
 var timeLimit = require('../');
 var fork      = require('child_process').fork;
 


### PR DESCRIPTION
With a very broken Promise implementation, it's possible that time-limit-promise will not behave correctly.

I've added a testcase that demonstrates what happens when a Promise never resolves and the event loop drains completely. I've also put a fix in that catches this case.

